### PR TITLE
Fix deploy errors related to twine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_deploy:
 - python3 -m pip install -U twine
 deploy:
   provider: script
-  script: twine upload --skip-existing wheelhouse/*
+  script: python3 -m twine upload --skip-existing wheelhouse/*
   skip_cleanup: true
   on:
     tags: true


### PR DESCRIPTION
While I couldn't check it, this should fix the deploy error when Travis tries to call `twine` that can be observed in the Mac build job.